### PR TITLE
Update StandardSlackService.java

### DIFF
--- a/src/main/java/jenkins/plugins/slack/StandardSlackService.java
+++ b/src/main/java/jenkins/plugins/slack/StandardSlackService.java
@@ -156,7 +156,7 @@ public class StandardSlackService implements SlackService {
     }
 
     private String getTokenToUse() {
-        if (authTokenCredentialId != null && !authTokenCredentialId.isEmpty()) {
+        if (token == null && authTokenCredentialId != null && !authTokenCredentialId.isEmpty()) {
             StringCredentials credentials = lookupCredentials(authTokenCredentialId);
             if (credentials != null) {
                 logger.fine("Using Integration Token Credential ID.");


### PR DESCRIPTION
If token is defined on jenkins step, use it instead of default authTokenCredentialId